### PR TITLE
Fix release command in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,6 @@ build:
 	poetry build
 
 publish:
-	make prepare
-	make config
 	poetry publish --build -r pypi
 
 clean:


### PR DESCRIPTION
Tried running the [release action](https://github.com/ThePalaceProject/webpub-manifest-parser/runs/2601154066) to publish a v1.0.0 release to PyPI. It looks like the make file is listing some targets for release that don't exist. I think we should be able to publish successfully after removing those.
