### PR TITLE
Parse date & time values using dateutil library as time zone aware

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1,199 +1,159 @@
 [[package]]
-category = "dev"
-description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 name = "appdirs"
+version = "1.4.4"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+category = "dev"
 optional = false
 python-versions = "*"
-version = "1.4.4"
 
 [[package]]
-category = "main"
-description = "Classes Without Boilerplate"
 name = "attrs"
+version = "20.2.0"
+description = "Classes Without Boilerplate"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "20.2.0"
 
 [package.extras]
-dev = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "sphinx", "sphinx-rtd-theme", "pre-commit"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "sphinx", "sphinx-rtd-theme", "pre-commit"]
 docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
-tests = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
-tests_no_zope = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
 
 [[package]]
-category = "dev"
-description = "Cross-platform colored terminal text."
-marker = "platform_system == \"Windows\""
 name = "colorama"
+version = "0.4.3"
+description = "Cross-platform colored terminal text."
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "0.4.3"
 
 [[package]]
-category = "main"
-description = "Updated configparser from Python 3.7 for Python 2.6+."
-marker = "python_version < \"3\""
 name = "configparser"
+version = "4.0.2"
+description = "Updated configparser from Python 3.7 for Python 2.6+."
+category = "main"
 optional = false
 python-versions = ">=2.6"
-version = "4.0.2"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2)", "pytest-flake8", "pytest-black-multipy"]
+testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2)", "pytest-flake8", "pytest-black-multipy"]
 
 [[package]]
-category = "main"
-description = "Backports and enhancements for the contextlib module"
-marker = "python_version < \"3.4\""
 name = "contextlib2"
+version = "0.6.0.post1"
+description = "Backports and enhancements for the contextlib module"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "0.6.0.post1"
 
 [[package]]
-category = "dev"
-description = "Distribution utilities"
 name = "distlib"
-optional = false
-python-versions = "*"
 version = "0.3.1"
+description = "Distribution utilities"
+category = "dev"
+optional = false
+python-versions = "*"
 
 [[package]]
-category = "main"
-description = "Python 3.4 Enum backported to 3.3, 3.2, 3.1, 2.7, 2.6, 2.5, and 2.4"
 name = "enum34"
-optional = false
-python-versions = "*"
 version = "1.1.10"
+description = "Python 3.4 Enum backported to 3.3, 3.2, 3.1, 2.7, 2.6, 2.5, and 2.4"
+category = "main"
+optional = false
+python-versions = "*"
 
 [[package]]
-category = "dev"
-description = "A platform independent file lock."
 name = "filelock"
-optional = false
-python-versions = "*"
 version = "3.0.12"
-
-[[package]]
+description = "A platform independent file lock."
 category = "dev"
-description = "Python function signatures from PEP362 for Python 2.6, 2.7 and 3.2+"
-marker = "python_version < \"3.3\""
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "funcsigs"
-optional = false
-python-versions = "*"
 version = "1.0.2"
-
-[[package]]
-category = "main"
-description = "Backport of the functools module from Python 3.2.3 for use on 2.7 and PyPy."
-marker = "python_version < \"3\""
-name = "functools32"
+description = "Python function signatures from PEP362 for Python 2.6, 2.7 and 3.2+"
+category = "dev"
 optional = false
 python-versions = "*"
-version = "3.2.3-2"
 
 [[package]]
+name = "functools32"
+version = "3.2.3-2"
+description = "Backport of the functools module from Python 3.2.3 for use on 2.7 and PyPy."
 category = "main"
-description = "Read metadata from Python packages"
-marker = "python_version < \"3.8\""
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "importlib-metadata"
+version = "1.7.0"
+description = "Read metadata from Python packages"
+category = "main"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-version = "1.7.0"
 
 [package.dependencies]
+configparser = {version = ">=3.5", markers = "python_version < \"3\""}
+contextlib2 = {version = "*", markers = "python_version < \"3\""}
+pathlib2 = {version = "*", markers = "python_version < \"3\""}
 zipp = ">=0.5"
-
-[package.dependencies.configparser]
-python = "<3"
-version = ">=3.5"
-
-[package.dependencies.contextlib2]
-python = "<3"
-version = "*"
-
-[package.dependencies.pathlib2]
-python = "<3"
-version = "*"
 
 [package.extras]
 docs = ["sphinx", "rst.linker"]
 testing = ["packaging", "pep517", "importlib-resources (>=1.3)"]
 
 [[package]]
-category = "dev"
-description = "Read resources from Python packages"
-marker = "python_version < \"3.7\""
 name = "importlib-resources"
+version = "3.0.0"
+description = "Read resources from Python packages"
+category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-version = "3.0.0"
 
 [package.dependencies]
-[package.dependencies.contextlib2]
-python = "<3"
-version = "*"
-
-[package.dependencies.pathlib2]
-python = "<3"
-version = "*"
-
-[package.dependencies.singledispatch]
-python = "<3.4"
-version = "*"
-
-[package.dependencies.typing]
-python = "<3.5"
-version = "*"
-
-[package.dependencies.zipp]
-python = "<3.8"
-version = ">=0.4"
+contextlib2 = {version = "*", markers = "python_version < \"3\""}
+pathlib2 = {version = "*", markers = "python_version < \"3\""}
+singledispatch = {version = "*", markers = "python_version < \"3.4\""}
+typing = {version = "*", markers = "python_version < \"3.5\""}
+zipp = {version = ">=0.4", markers = "python_version < \"3.8\""}
 
 [package.extras]
 docs = ["sphinx", "rst.linker", "jaraco.packaging"]
 
 [[package]]
-category = "main"
-description = "An implementation of JSON Schema validation for Python"
 name = "jsonschema"
+version = "3.2.0"
+description = "An implementation of JSON Schema validation for Python"
+category = "main"
 optional = false
 python-versions = "*"
-version = "3.2.0"
 
 [package.dependencies]
 attrs = ">=17.4.0"
+functools32 = {version = "*", markers = "python_version < \"3\""}
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 pyrsistent = ">=0.14.0"
-setuptools = "*"
 six = ">=1.11.0"
-
-[package.dependencies.functools32]
-python = "<3"
-version = "*"
-
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = "*"
 
 [package.extras]
 format = ["idna", "jsonpointer (>1.13)", "rfc3987", "strict-rfc3339", "webcolors"]
 format_nongpl = ["idna", "jsonpointer (>1.13)", "webcolors", "rfc3986-validator (>0.1.0)", "rfc3339-validator"]
 
 [[package]]
-category = "dev"
-description = "Rolling backport of unittest.mock for all Pythons"
 name = "mock"
+version = "3.0.5"
+description = "Rolling backport of unittest.mock for all Pythons"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "3.0.5"
 
 [package.dependencies]
+funcsigs = {version = ">=1", markers = "python_version < \"3.3\""}
 six = "*"
-
-[package.dependencies.funcsigs]
-python = "<3.3"
-version = ">=1"
 
 [package.extras]
 build = ["twine", "wheel", "blurb"]
@@ -201,189 +161,185 @@ docs = ["sphinx"]
 test = ["pytest", "pytest-cov"]
 
 [[package]]
-category = "main"
-description = "Multiple dispatch"
 name = "multipledispatch"
+version = "0.6.0"
+description = "Multiple dispatch"
+category = "main"
 optional = false
 python-versions = "*"
-version = "0.6.0"
 
 [package.dependencies]
 six = "*"
 
 [[package]]
-category = "dev"
-description = "nose extends unittest to make testing easier"
 name = "nose"
+version = "1.3.7"
+description = "nose extends unittest to make testing easier"
+category = "dev"
 optional = false
 python-versions = "*"
-version = "1.3.7"
 
 [[package]]
-category = "dev"
-description = "A timer plugin for nosetests"
 name = "nose-timer"
+version = "1.0.0"
+description = "A timer plugin for nosetests"
+category = "dev"
 optional = false
 python-versions = "*"
-version = "1.0.0"
 
 [package.dependencies]
 nose = "*"
 
 [[package]]
-category = "dev"
-description = "Core utilities for Python packages"
 name = "packaging"
+version = "20.4"
+description = "Core utilities for Python packages"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "20.4"
 
 [package.dependencies]
 pyparsing = ">=2.0.2"
 six = "*"
 
 [[package]]
-category = "dev"
-description = "Parameterized testing with any Python test framework"
 name = "parameterized"
+version = "0.7.4"
+description = "Parameterized testing with any Python test framework"
+category = "dev"
 optional = false
 python-versions = "*"
-version = "0.7.4"
 
 [package.extras]
 dev = ["jinja2"]
 
 [[package]]
-category = "main"
-description = "Object-oriented filesystem paths"
-marker = "python_version < \"3.4\" and sys_platform != \"win32\" or python_version < \"3\""
 name = "pathlib2"
+version = "2.3.5"
+description = "Object-oriented filesystem paths"
+category = "main"
 optional = false
 python-versions = "*"
-version = "2.3.5"
 
 [package.dependencies]
+scandir = {version = "*", markers = "python_version < \"3.5\""}
 six = "*"
 
-[package.dependencies.scandir]
-python = "<3.5"
-version = "*"
-
 [[package]]
-category = "dev"
-description = "plugin and hook calling mechanisms for python"
 name = "pluggy"
+version = "0.13.1"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "0.13.1"
 
 [package.dependencies]
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = ">=0.12"
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
 dev = ["pre-commit", "tox"]
 
 [[package]]
-category = "dev"
-description = "library with cross-python path, ini-parsing, io, code, log facilities"
 name = "py"
+version = "1.9.0"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.9.0"
 
 [[package]]
-category = "dev"
-description = "pyfakefs implements a fake file system that mocks the Python file system modules."
 name = "pyfakefs"
+version = "3.7"
+description = "pyfakefs implements a fake file system that mocks the Python file system modules."
+category = "dev"
 optional = false
 python-versions = "*"
-version = "3.7"
 
 [[package]]
-category = "dev"
-description = "Python parsing module"
 name = "pyparsing"
+version = "2.4.7"
+description = "Python parsing module"
+category = "dev"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "2.4.7"
 
 [[package]]
-category = "main"
-description = "Persistent/Functional/Immutable data structures"
 name = "pyrsistent"
+version = "0.16.1"
+description = "Persistent/Functional/Immutable data structures"
+category = "main"
 optional = false
 python-versions = ">=2.7"
-version = "0.16.1"
 
 [package.dependencies]
 six = "*"
 
 [[package]]
+name = "python-dateutil"
+version = "2.8.2"
+description = "Extensions to the standard Python datetime module"
 category = "main"
-description = "Parsing and validation of URIs (RFC 3986) and IRIs (RFC 3987)"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "rfc3987"
-optional = false
-python-versions = "*"
 version = "1.3.8"
-
-[[package]]
+description = "Parsing and validation of URIs (RFC 3986) and IRIs (RFC 3987)"
 category = "main"
-description = "scandir, a better directory iterator and faster os.walk()"
-marker = "python_version < \"3\" and sys_platform != \"win32\" or python_version < \"3\" or python_version < \"3.4\" and sys_platform != \"win32\" and (python_version < \"3.4\" and sys_platform != \"win32\" or python_version < \"3\")"
-name = "scandir"
 optional = false
 python-versions = "*"
-version = "1.10.0"
 
 [[package]]
-category = "dev"
-description = "This library brings functools.singledispatch from Python 3.4 to Python 2.6-3.3."
-marker = "python_version < \"3.4\""
-name = "singledispatch"
+name = "scandir"
+version = "1.10.0"
+description = "scandir, a better directory iterator and faster os.walk()"
+category = "main"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "singledispatch"
 version = "3.4.0.3"
+description = "This library brings functools.singledispatch from Python 3.4 to Python 2.6-3.3."
+category = "dev"
+optional = false
+python-versions = "*"
 
 [package.dependencies]
 six = "*"
 
 [[package]]
-category = "main"
-description = "Python 2 and 3 compatibility utilities"
 name = "six"
+version = "1.15.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "1.15.0"
 
 [[package]]
-category = "main"
-description = "Strict, simple, lightweight RFC3339 functions"
-name = "strict-rfc3339"
-optional = false
-python-versions = "*"
-version = "0.7"
-
-[[package]]
-category = "dev"
-description = "Python Library for Tom's Obvious, Minimal Language"
 name = "toml"
+version = "0.10.1"
+description = "Python Library for Tom's Obvious, Minimal Language"
+category = "dev"
 optional = false
 python-versions = "*"
-version = "0.10.1"
 
 [[package]]
-category = "dev"
-description = "tox is a generic virtualenv management and test command line tool"
 name = "tox"
+version = "3.20.0"
+description = "tox is a generic virtualenv management and test command line tool"
+category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-version = "3.20.0"
 
 [package.dependencies]
-colorama = ">=0.4.1"
+colorama = {version = ">=0.4.1", markers = "platform_system == \"Windows\""}
 filelock = ">=3.0.0"
+importlib-metadata = {version = ">=0.12,<2", markers = "python_version < \"3.8\""}
 packaging = ">=14"
 pluggy = ">=0.12.0"
 py = ">=1.4.17"
@@ -391,94 +347,77 @@ six = ">=1.14.0"
 toml = ">=0.9.4"
 virtualenv = ">=16.0.0,<20.0.0 || >20.0.0,<20.0.1 || >20.0.1,<20.0.2 || >20.0.2,<20.0.3 || >20.0.3,<20.0.4 || >20.0.4,<20.0.5 || >20.0.5,<20.0.6 || >20.0.6,<20.0.7 || >20.0.7"
 
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = ">=0.12,<2"
-
 [package.extras]
 docs = ["pygments-github-lexers (>=0.0.5)", "sphinx (>=2.0.0)", "sphinxcontrib-autoprogram (>=0.1.5)", "towncrier (>=18.5.0)"]
 testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "pathlib2 (>=2.3.3)", "psutil (>=5.6.1)", "pytest (>=4.0.0)", "pytest-cov (>=2.5.1)", "pytest-mock (>=1.10.0)", "pytest-randomly (>=1.0.0)", "pytest-xdist (>=1.22.2)"]
 
 [[package]]
-category = "dev"
-description = "tox plugin that makes tox use `pyenv which` to find python executables"
 name = "tox-pyenv"
+version = "1.1.0"
+description = "tox plugin that makes tox use `pyenv which` to find python executables"
+category = "dev"
 optional = false
 python-versions = "*"
-version = "1.1.0"
 
 [package.dependencies]
 tox = ">=2.0"
 
 [[package]]
-category = "dev"
-description = "Type Hints for Python"
-marker = "python_version < \"3.5\""
 name = "typing"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "3.7.4.3"
-
-[[package]]
-category = "main"
-description = "URI templates"
-name = "uritemplate"
+description = "Type Hints for Python"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "3.0.1"
 
 [[package]]
-category = "dev"
-description = "Virtual Python Environment builder"
+name = "uritemplate"
+version = "3.0.1"
+description = "URI templates"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
 name = "virtualenv"
+version = "20.0.31"
+description = "Virtual Python Environment builder"
+category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "20.0.31"
 
 [package.dependencies]
 appdirs = ">=1.4.3,<2"
 distlib = ">=0.3.1,<1"
 filelock = ">=3.0.0,<4"
+importlib-metadata = {version = ">=0.12,<2", markers = "python_version < \"3.8\""}
+importlib-resources = {version = ">=1.0", markers = "python_version < \"3.7\""}
+pathlib2 = {version = ">=2.3.3,<3", markers = "python_version < \"3.4\" and sys_platform != \"win32\""}
 six = ">=1.9.0,<2"
-
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = ">=0.12,<2"
-
-[package.dependencies.importlib-resources]
-python = "<3.7"
-version = ">=1.0"
-
-[package.dependencies.pathlib2]
-python = "<3.4"
-version = ">=2.3.3,<3"
 
 [package.extras]
 docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=19.9.0rc1)"]
 testing = ["coverage (>=5)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "pytest-xdist (>=1.31.0)", "packaging (>=20.0)", "xonsh (>=0.9.16)"]
 
 [[package]]
-category = "main"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-marker = "python_version < \"3.8\""
 name = "zipp"
+version = "1.2.0"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+category = "main"
 optional = false
 python-versions = ">=2.7"
-version = "1.2.0"
 
 [package.dependencies]
-[package.dependencies.contextlib2]
-python = "<3.4"
-version = "*"
+contextlib2 = {version = "*", markers = "python_version < \"3.4\""}
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pathlib2", "unittest2", "jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "0b42c9de70229f13c3ddbfaa6c4c4e6786b80aa17e71cdfbe26db98dd38c5a8d"
-lock-version = "1.0"
+lock-version = "1.1"
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+content-hash = "2d06525d4a2c9b78e19ab5db98e8205ef243487d33fe684f985d379b3be71159"
 
 [metadata.files]
 appdirs = [
@@ -582,6 +521,10 @@ pyparsing = [
 pyrsistent = [
     {file = "pyrsistent-0.16.1.tar.gz", hash = "sha256:aa2ae1c2e496f4d6777f869ea5de7166a8ccb9c2e06ebcf6c7ff1b670c98c5ef"},
 ]
+python-dateutil = [
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
 rfc3987 = [
     {file = "rfc3987-1.3.8-py2.py3-none-any.whl", hash = "sha256:10702b1e51e5658843460b189b185c0366d2cf4cff716f13111b0ea9fd2dce53"},
     {file = "rfc3987-1.3.8.tar.gz", hash = "sha256:d3c4d257a560d544e9826b38bc81db676890c79ab9d7ac92b39c7a253d5ca733"},
@@ -606,9 +549,6 @@ singledispatch = [
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
     {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
-]
-strict-rfc3339 = [
-    {file = "strict-rfc3339-0.7.tar.gz", hash = "sha256:5cad17bedfc3af57b399db0fed32771f18fc54bbd917e85546088607ac5e1277"},
 ]
 toml = [
     {file = "toml-0.10.1-py2.py3-none-any.whl", hash = "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,10 +28,10 @@ python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 multipledispatch = "^0.6.0"
 enum34 = "^1.1.10"
 jsonschema = "^3.2.0"
-strict-rfc3339 = "^0.7"
 rfc3987 = "^1.3.8"
 pyrsistent = "0.16.1"
 uritemplate = "^3.0.1"
+python-dateutil = "^2.8.2"
 
 [tool.poetry.dev-dependencies]
 pyfakefs = "3.7"

--- a/src/webpub_manifest_parser/core/parsers.py
+++ b/src/webpub_manifest_parser/core/parsers.py
@@ -1,4 +1,3 @@
-import datetime
 import logging
 import re
 from abc import ABCMeta, abstractmethod
@@ -6,7 +5,7 @@ from pydoc import locate
 
 import jsonschema  # noqa: I201
 import six  # noqa: I201
-import strict_rfc3339  # noqa: I201
+from dateutil import parser as datetime_parser  # noqa: I201, I100
 from jsonschema import FormatError  # noqa: I201, I100
 from uritemplate import URITemplate  # noqa: I201
 
@@ -477,14 +476,10 @@ class URIReferenceParser(FormatChecker):
         return value
 
 
-class DateParser(FormatChecker):
+class DateParser(StringParser):
     """Date parser."""
 
-    def __init__(self):
-        """Initialize a new instance of DateParser class."""
-        super(DateParser, self).__init__("date")
-
-    def _parse(self, value):
+    def parse(self, value):
         """Parse a date & time string into datetime object.
 
         :param value: Value
@@ -494,25 +489,19 @@ class DateParser(FormatChecker):
         :rtype: datetime.datetime
         """
         try:
-            return datetime.datetime.strptime(value, "%Y-%m-%d")
+            return datetime_parser.parse(value)
         except Exception as exception:
             raise ValueParserError(
                 value,
-                u"Value '{0}' is not a correct date: it does not match '%Y-%m-%d' pattern".format(
-                    encode(value)
-                ),
+                u"Value '{0}' is not a correct date".format(encode(value)),
                 exception,
             )
 
 
-class DateTimeParser(FormatChecker):
+class DateTimeParser(StringParser):
     """Date & time parser."""
 
-    def __init__(self):
-        """Initialize a new instance of DateTimeParser class."""
-        super(DateTimeParser, self).__init__("date-time")
-
-    def _parse(self, value):
+    def parse(self, value):
         """Parse a date & time string into datetime object.
 
         :param value: Value
@@ -522,14 +511,12 @@ class DateTimeParser(FormatChecker):
         :rtype: datetime.datetime
         """
         try:
-            timestamp = strict_rfc3339.rfc3339_to_timestamp(value)
-
-            return datetime.datetime.utcfromtimestamp(timestamp)
+            return datetime_parser.parse(value)
         except Exception as exception:
             raise ValueParserError(
                 value,
-                u"Value '{0}' is not correct date & time value: "
-                u"it does not comply with RFC 3339 date & time formatting rules".format(
+                u"Value '{0}' is not a correct date & time value: "
+                u"it does not comply with ISO 8601 date & time formatting rules".format(
                     encode(value)
                 ),
                 exception,

--- a/tests/webpub_manifest_parser/core/test_analyzer.py
+++ b/tests/webpub_manifest_parser/core/test_analyzer.py
@@ -334,6 +334,8 @@ class NodeFinderTest(TestCase):
     def test(self, _, root, target_node, target_parent_class, expected_parent_node):
         node_finder = NodeFinder()
 
-        parent_node = node_finder.find_parent_or_self(root, target_node, target_parent_class)
+        parent_node = node_finder.find_parent_or_self(
+            root, target_node, target_parent_class
+        )
 
         self.assertEqual(expected_parent_node, parent_node)

--- a/tests/webpub_manifest_parser/core/test_syntax.py
+++ b/tests/webpub_manifest_parser/core/test_syntax.py
@@ -1,6 +1,7 @@
 import datetime
 from unittest import TestCase
 
+from dateutil.tz import tzutc
 from parameterized import parameterized
 
 from tests.webpub_manifest_parser.core.test_analyzer import AnalyzerTest
@@ -32,7 +33,7 @@ class SyntaxAnalyzerTest(AnalyzerTest):
                 {"metadata": {"modified": "2021-01-01T00:00:00Z"}},
                 Manifestlike(
                     metadata=PresentationMetadata(
-                        modified=datetime.datetime(2021, 1, 1),
+                        modified=datetime.datetime(2021, 1, 1, tzinfo=tzutc()),
                         languages=[],
                         authors=[],
                         translators=[],
@@ -59,7 +60,7 @@ class SyntaxAnalyzerTest(AnalyzerTest):
             #    and continues parsing other nested properties (`subtitle`, etc.).
             (
                 "incorrect_metadata_modified_property",
-                {"metadata": {"subtitle": "Subtitle", "modified": "2021"}},
+                {"metadata": {"subtitle": "Subtitle", "modified": "202X"}},
                 Manifestlike(
                     metadata=PresentationMetadata(
                         subtitle="Subtitle",
@@ -87,7 +88,8 @@ class SyntaxAnalyzerTest(AnalyzerTest):
                     SyntaxAnalyzerError(
                         PresentationMetadata(),
                         Metadata.modified,
-                        u"'2021' is not a 'date-time'",
+                        u"Value '202X' is not a correct date & time value: "
+                        u"it does not comply with ISO 8601 date & time formatting rules",
                     ),
                 ],
             ),
@@ -99,7 +101,7 @@ class SyntaxAnalyzerTest(AnalyzerTest):
                     "metadata": {
                         "title": "Title",
                         "subtitle": "Subtitle",
-                        "modified": "2021",
+                        "modified": "202X",
                     }
                 },
                 Manifestlike(
@@ -129,7 +131,8 @@ class SyntaxAnalyzerTest(AnalyzerTest):
                     SyntaxAnalyzerError(
                         PresentationMetadata(),
                         Metadata.modified,
-                        u"'2021' is not a 'date-time'",
+                        u"Value '202X' is not a correct date & time value: "
+                        u"it does not comply with ISO 8601 date & time formatting rules",
                     ),
                 ],
             ),

--- a/tests/webpub_manifest_parser/odl/test_parser.py
+++ b/tests/webpub_manifest_parser/odl/test_parser.py
@@ -2,6 +2,8 @@ import datetime
 import os
 from unittest import TestCase
 
+from dateutil.tz import tzoffset
+
 from webpub_manifest_parser.core import ManifestParserResult
 from webpub_manifest_parser.odl import ODLFeedParserFactory
 from webpub_manifest_parser.opds2.ast import OPDS2FeedMetadata
@@ -44,12 +46,14 @@ class ODLParserTest(TestCase):
         self.assertEqual(7.99, license.metadata.price.value)
 
         self.assertEqual(
-            datetime.datetime(2014, 4, 25, 10, 25, 21), license.metadata.created
+            datetime.datetime(2014, 4, 25, 12, 25, 21, tzinfo=tzoffset(None, 7200)),
+            license.metadata.created,
         )
 
         self.assertEqual(30, license.metadata.terms.checkouts)
         self.assertEqual(
-            datetime.datetime(2016, 4, 25, 10, 25, 21), license.metadata.terms.expires
+            datetime.datetime(2016, 4, 25, 12, 25, 21, tzinfo=tzoffset(None, 7200)),
+            license.metadata.terms.expires,
         )
         self.assertEqual(10, license.metadata.terms.concurrency)
         self.assertEqual(5097600, license.metadata.terms.length)

--- a/tests/webpub_manifest_parser/opds2/test_parser.py
+++ b/tests/webpub_manifest_parser/opds2/test_parser.py
@@ -2,6 +2,8 @@ import datetime
 import os
 from unittest import TestCase
 
+from dateutil.tz import tzutc
+
 from webpub_manifest_parser.core import ManifestParserResult
 from webpub_manifest_parser.core.ast import (
     CompactCollection,
@@ -67,7 +69,8 @@ class OPDS2ParserTest(TestCase):
         self.assertEqual("urn:isbn:978-3-16-148410-0", publication.metadata.identifier)
         self.assertEqual(["en"], publication.metadata.languages)
         self.assertEqual(
-            datetime.datetime(2015, 9, 29, 17, 0, 0), publication.metadata.modified
+            datetime.datetime(2015, 9, 29, 17, 0, tzinfo=tzutc()),
+            publication.metadata.modified,
         )
 
         self.assertIsInstance(publication.links, list)
@@ -146,10 +149,12 @@ class OPDS2ParserTest(TestCase):
         self.assertEqual("urn:isbn:978-3-16-148410-0", publication.metadata.identifier)
         self.assertEqual(["eng", "fre"], publication.metadata.languages)
         self.assertEqual(
-            datetime.datetime(2015, 9, 29, 0, 0, 0), publication.metadata.published
+            datetime.datetime(2015, 9, 29, 0, 0, tzinfo=tzutc()),
+            publication.metadata.published,
         )
         self.assertEqual(
-            datetime.datetime(2015, 9, 29, 17, 0, 0), publication.metadata.modified
+            datetime.datetime(2015, 9, 29, 17, 0, 0, tzinfo=tzutc()),
+            publication.metadata.modified,
         )
 
         self.assertIsInstance(publication.links, list)

--- a/tests/webpub_manifest_parser/rwpm/test_parser.py
+++ b/tests/webpub_manifest_parser/rwpm/test_parser.py
@@ -2,6 +2,8 @@ import datetime
 import os
 from unittest import TestCase
 
+from dateutil.tz import tzutc
+
 from webpub_manifest_parser.core import ManifestParserResult
 from webpub_manifest_parser.core.ast import (
     CompactCollection,
@@ -52,7 +54,8 @@ class RWPMManifestParserTest(TestCase):
         self.assertEqual("urn:isbn:978031600000X", manifest.metadata.identifier)
         self.assertEqual(["en"], manifest.metadata.languages)
         self.assertEqual(
-            datetime.datetime(2015, 9, 29, 17, 0, 0), manifest.metadata.modified
+            datetime.datetime(2015, 9, 29, 17, 0, 0, tzinfo=tzutc()),
+            manifest.metadata.modified,
         )
 
         self.assertIsInstance(manifest.links, list)

--- a/tests/webpub_manifest_parser/rwpm/test_syntax.py
+++ b/tests/webpub_manifest_parser/rwpm/test_syntax.py
@@ -2,6 +2,7 @@ import datetime
 from unittest import TestCase
 
 import six
+from dateutil.tz import tzutc
 from parameterized import parameterized
 
 from webpub_manifest_parser.core import ManifestParser
@@ -522,7 +523,7 @@ class RWPMSyntaxAnalyzerTest(TestCase):
             (
                 "when_metadata_modified_property_has_incorrect_format",
                 RWPM_MANIFEST_WITH_INCORRECT_METADATA_MODIFIED_PROPERTY,
-                "'2015-09-29T17:00:00Z---' is not a 'date-time'",
+                "Value '2015-09-29T17:00:00Z---' is not a correct date & time value: it does not comply with ISO 8601 date & time formatting rules",
             ),
             (
                 "when_metadata_modified_language_has_incorrect_format",
@@ -640,7 +641,8 @@ class RWPMSyntaxAnalyzerTest(TestCase):
         self.assertEqual("urn:isbn:978031600000X", manifest.metadata.identifier)
         self.assertEqual(["en"], manifest.metadata.languages)
         self.assertEqual(
-            datetime.datetime(2015, 9, 29, 17, 0, 0), manifest.metadata.modified
+            datetime.datetime(2015, 9, 29, 17, 0, 0, tzinfo=tzutc()),
+            manifest.metadata.modified,
         )
 
         self.assertIsInstance(manifest.links, list)


### PR DESCRIPTION
This PR changes the code responsible for parsing date & values. It replaces `datetime.datetime.strptime` and `strict_rfc3339` with `datetutil.parser.parse` method that covers most of the requirements of ISO 8601/RFC 3339 and returns time zone aware date & time objects.