### PR TITLE
Fix various issues related to date & time parsing

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -286,6 +286,14 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 six = ">=1.5"
 
 [[package]]
+name = "pytz"
+version = "2021.1"
+description = "World timezone definitions, modern and historical"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "rfc3987"
 version = "1.3.8"
 description = "Parsing and validation of URIs (RFC 3986) and IRIs (RFC 3987)"
@@ -417,7 +425,7 @@ testing = ["pathlib2", "unittest2", "jaraco.itertools", "func-timeout"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-content-hash = "2d06525d4a2c9b78e19ab5db98e8205ef243487d33fe684f985d379b3be71159"
+content-hash = "28f995b8408bd6518ac015fb525946d19631e9bdff7252a0b6ecb73dad3d74cd"
 
 [metadata.files]
 appdirs = [
@@ -524,6 +532,10 @@ pyrsistent = [
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
     {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
+pytz = [
+    {file = "pytz-2021.1-py2.py3-none-any.whl", hash = "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"},
+    {file = "pytz-2021.1.tar.gz", hash = "sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da"},
 ]
 rfc3987 = [
     {file = "rfc3987-1.3.8-py2.py3-none-any.whl", hash = "sha256:10702b1e51e5658843460b189b185c0366d2cf4cff716f13111b0ea9fd2dce53"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ rfc3987 = "^1.3.8"
 pyrsistent = "0.16.1"
 uritemplate = "^3.0.1"
 python-dateutil = "^2.8.2"
+pytz = "^2021.1"
 
 [tool.poetry.dev-dependencies]
 pyfakefs = "3.7"

--- a/tests/webpub_manifest_parser/core/test_parsers.py
+++ b/tests/webpub_manifest_parser/core/test_parsers.py
@@ -1,5 +1,9 @@
+import datetime
+from abc import ABCMeta
 from unittest import TestCase
 
+import pytz
+import six
 from nose.tools import assert_raises
 from parameterized import parameterized
 
@@ -11,44 +15,209 @@ from webpub_manifest_parser.core.ast import (
 from webpub_manifest_parser.core.parsers import (
     AnyOfParser,
     ArrayParser,
+    DateParser,
+    DateTimeParser,
     NumberParser,
     StringParser,
     TypeParser,
     URIParser,
+    ValueParser,
     ValueParserError,
     find_parser,
 )
 
 
-class NumberParserTest(TestCase):
-    @parameterized.expand(
-        [("correct_number", "123"), ("incorrect_number", "abc", ValueParserError)]
-    )
-    def test(self, _, value, expected_error_class=None):
-        validator = NumberParser()
+@six.add_metaclass(ABCMeta)
+class ParserTest(object):
+    PARSER_CLASS = ValueParser
 
-        if expected_error_class:
-            with assert_raises(expected_error_class):
-                validator.parse(value)
+    def _create_parser(self):
+        return self.PARSER_CLASS()
+
+    def test(self, _, value, expected_result, expected_error=None):
+        """Ensure that the parser returns the expected result or raises the expected exception."""
+        parser = self._create_parser()
+
+        if expected_error:
+            with assert_raises(expected_error.__class__) as error_context:
+                parser.parse(value)
+
+            self.assertEqual(
+                error_context.exception.error_message, expected_error.error_message
+            )
         else:
-            validator.parse(value)
+            result = parser.parse(value)
+
+            self.assertEqual(expected_result, result)
 
 
-class URIParserTest(TestCase):
+class NumberParserTest(ParserTest, TestCase):
+    PARSER_CLASS = NumberParser
+
     @parameterized.expand(
         [
-            ("correct_uri", "http://example.com"),
-            ("incorrect_uri", "123", ValueParserError),
+            ("correct_number", "123", 123),
+            (
+                "incorrect_number",
+                "abc",
+                None,
+                ValueParserError("abc", "could not convert string to float: 'abc'")
+                if six.PY3
+                else ValueParserError("abc", "could not convert string to float: abc"),
+            ),
         ]
     )
-    def test(self, _, value, expected_error_class=None):
-        validator = URIParser()
+    def test(self, _, value, expected_result, expected_error_class=None):
+        super(NumberParserTest, self).test(
+            _, value, expected_result, expected_error_class
+        )
 
-        if expected_error_class:
-            with assert_raises(expected_error_class):
-                validator.parse(value)
-        else:
-            validator.parse(value)
+
+class URIParserTest(ParserTest, TestCase):
+    PARSER_CLASS = URIParser
+
+    @parameterized.expand(
+        [
+            ("correct_uri", "http://example.com", "http://example.com"),
+            (
+                "incorrect_uri",
+                "123",
+                None,
+                ValueParserError("123", "'123' is not a 'uri'"),
+            ),
+        ]
+    )
+    def test(self, _, value, expected_result, expected_error_class=None):
+        super(URIParserTest, self).test(_, value, expected_result, expected_error_class)
+
+
+class DateParserTest(ParserTest, TestCase):
+    PARSER_CLASS = DateParser
+
+    @parameterized.expand(
+        [
+            (
+                "yyyy",
+                "2020",
+                datetime.datetime(2020, 1, 1, 0, 0),
+            ),
+            (
+                "yyyy",
+                2020,
+                None,
+                ValueParserError("2020", "Value '2020' must be a string"),
+            ),
+            (
+                "yyyy-mm",
+                "2020-01",
+                datetime.datetime(2020, 1, 1),
+            ),
+            ("yyyy-mm-dd", "2020-01-01", datetime.datetime(2020, 1, 1)),
+            (
+                "incorrect_date",
+                "2020-01-0",
+                None,
+                ValueParserError(
+                    "2020-01-0", "Value '2020-01-0' is not a correct date"
+                ),
+            ),
+            (
+                "yyyy-mm-ddThh:mm:ss",
+                "2020-01-01T10:10:10",
+                None,
+                ValueParserError(
+                    "2020-01-01T10:10:10",
+                    "Value '2020-01-01T10:10:10' is not a correct date",
+                ),
+            ),
+            (
+                "yyyy-mm-ddThh:mm:ss",
+                "2020-01-01 10:10:10",
+                None,
+                ValueParserError(
+                    "2020-01-01 10:10:10",
+                    "Value '2020-01-01 10:10:10' is not a correct date",
+                ),
+            ),
+            (
+                "yyyy-mm-ddThh:mm:ss",
+                "2020-01-01 10:10:10-03:00",
+                None,
+                ValueParserError(
+                    "2020-01-01 10:10:10-03:00",
+                    "Value '2020-01-01 10:10:10-03:00' is not a correct date",
+                ),
+            ),
+        ]
+    )
+    def test(self, _, value, expected_result, expected_error_class=None):
+        super(DateParserTest, self).test(
+            _, value, expected_result, expected_error_class
+        )
+
+
+class DateTimeParserTest(ParserTest, TestCase):
+    PARSER_CLASS = DateTimeParser
+
+    @parameterized.expand(
+        [
+            (
+                "yyyy",
+                "2020",
+                datetime.datetime(2020, 1, 1),
+            ),
+            (
+                "yyyy",
+                2020,
+                None,
+                ValueParserError("2020", "Value '2020' must be a string"),
+            ),
+            (
+                "yyyy-mm",
+                "2020-01",
+                datetime.datetime(2020, 1, 1),
+            ),
+            ("yyyy-mm-dd", "2020-01-01", datetime.datetime(2020, 1, 1)),
+            (
+                "incorrect_date",
+                "2020-01-0",
+                None,
+                ValueParserError(
+                    "2020-01-0",
+                    "Value '2020-01-0' is not a correct date & time value: it does not comply with ISO 8601 date & time formatting rules",
+                ),
+            ),
+            (
+                "yyyy-mm-ddThh:mm:ss",
+                "2020-01-01T10:10:10",
+                datetime.datetime(2020, 1, 1, 10, 10, 10),
+            ),
+            (
+                "yyyy-mm-ddThh:mm:ss",
+                "2020-01-01 10:10:10",
+                datetime.datetime(2020, 1, 1, 10, 10, 10),
+            ),
+            (
+                "yyyy-mm-ddThh:mm:ss",
+                "2020-01-01 10:10:10-03:00",
+                datetime.datetime(
+                    2020,
+                    1,
+                    1,
+                    10,
+                    10,
+                    10,
+                    tzinfo=pytz.FixedOffset(
+                        datetime.timedelta(hours=-3).total_seconds() / 60
+                    ),
+                ),
+            ),
+        ]
+    )
+    def test(self, _, value, expected_result, expected_error_class=None):
+        super(DateTimeParserTest, self).test(
+            _, value, expected_result, expected_error_class
+        )
 
 
 class FunctionsTest(TestCase):


### PR DESCRIPTION
This PR fixes various issues related to date & time parsing:
1. It replaces `dateutil.parser.parse` with `dateutil.parser.isoparse` method to strictly conform to date & time formatting standards declared both in [JSON Schema](https://json-schema.org/understanding-json-schema/reference/string.html#dates-and-times) and [OPDS 2.x](https://github.com/opds-community/drafts/blob/master/opds-2.0.md).
2. It adds additional tests for date & time parsers.