### PR TITLE
Update enum34 dependancy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ packages = [
 [tool.poetry.dependencies]
 python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 multipledispatch = "^0.6.0"
-enum34 = "^1.1.10"
+enum34 = { version = "^1.1.10", python = "< 3.4" }
 jsonschema = "^3.2.0"
 rfc3987 = "^1.3.8"
 pyrsistent = "0.16.1"

--- a/tox.ini
+++ b/tox.ini
@@ -126,7 +126,8 @@ disable =
     too-many-ancestors,
     duplicate-code,
     raise-missing-from,
-    too-many-lines
+    too-many-lines,
+    consider-using-f-string
 
 [gh-actions]
 python =


### PR DESCRIPTION
`Enum34` causes a lot of issues installing packages, and it isn't actually needed in newer Python versions.