### PR TITLE
Unsupported property values should fallback to default as opposed to …

### DIFF
--- a/src/webpub_manifest_parser/core/ast.py
+++ b/src/webpub_manifest_parser/core/ast.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from abc import ABCMeta, abstractmethod
+from typing import TypeVar
 
 from webpub_manifest_parser.core.parsers import (
     AnyOfParser,
@@ -27,6 +30,13 @@ from webpub_manifest_parser.core.properties import (
 )
 from webpub_manifest_parser.core.registry import CollectionRole
 from webpub_manifest_parser.utils import encode
+
+T = TypeVar("T")
+
+
+def _safe_tuple(value: list[T] | T) -> tuple[T] | T:
+    """Convert a value to a tuple if it is a list only"""
+    return tuple(value) if isinstance(value, list) else value
 
 
 class Visitor(metaclass=ABCMeta):
@@ -269,17 +279,15 @@ class Link(Node):
                 self.templated,
                 self.type,
                 self.title,
-                tuple(self.rels),
+                _safe_tuple(self.rels),
                 self.properties,
                 self.height,
                 self.width,
                 self.duration,
                 self.bitrate,
-                tuple(self.languages)
-                if isinstance(self.languages, list)
-                else self.languages,
-                tuple(self.alternates),
-                tuple(self.children),
+                _safe_tuple(self.languages),
+                _safe_tuple(self.alternates),
+                _safe_tuple(self.children),
             )
         )
 
@@ -525,7 +533,7 @@ class Subject(Node, PropertiesGrouping):
         :rtype: int
         """
         return hash(
-            (self.name, self.sort_as, self.code, self.scheme, tuple(self.links))
+            (self.name, self.sort_as, self.code, self.scheme, _safe_tuple(self.links))
         )
 
     def __repr__(self):
@@ -593,7 +601,7 @@ class Owner(Node, PropertiesGrouping):
         :return: Hash
         :rtype: int
         """
-        return hash((tuple(self.collection), tuple(self.series)))
+        return hash((_safe_tuple(self.collection), _safe_tuple(self.series)))
 
     def __repr__(self):
         """Return a string representation of the object.
@@ -756,22 +764,22 @@ class Metadata(Node):
                 self.subtitle,
                 self.modified,
                 self.published,
-                tuple(self.languages),
+                _safe_tuple(self.languages),
                 self.sort_as,
-                tuple(self.authors),
-                tuple(self.translators),
-                tuple(self.editors),
-                tuple(self.artists),
-                tuple(self.illustrators),
-                tuple(self.letterers),
-                tuple(self.pencilers),
-                tuple(self.colorists),
-                tuple(self.inkers),
-                tuple(self.narrators),
-                tuple(self.contributors),
-                tuple(self.publishers),
-                tuple(self.imprints),
-                tuple(self.subjects),
+                _safe_tuple(self.authors),
+                _safe_tuple(self.translators),
+                _safe_tuple(self.editors),
+                _safe_tuple(self.artists),
+                _safe_tuple(self.illustrators),
+                _safe_tuple(self.letterers),
+                _safe_tuple(self.pencilers),
+                _safe_tuple(self.colorists),
+                _safe_tuple(self.inkers),
+                _safe_tuple(self.narrators),
+                _safe_tuple(self.contributors),
+                _safe_tuple(self.publishers),
+                _safe_tuple(self.imprints),
+                _safe_tuple(self.subjects),
                 self.description,
                 self.duration,
                 self.number_of_pages,

--- a/src/webpub_manifest_parser/core/syntax.py
+++ b/src/webpub_manifest_parser/core/syntax.py
@@ -280,7 +280,8 @@ class SyntaxAnalyzer(BaseAnalyzer):
                 property_value = object_property.parser.parse(property_value)
             except ValueParserError as error:
                 # First, fallback to the default value for the property, then re-raise
-                setattr(ast_object, object_property_name, object_property.default_value)        
+                property_value = self._format_property_value(object_property.default_value, object_property)
+                setattr(ast_object, object_property_name, property_value)
                 raise SyntaxAnalyzerError(
                     ast_object, object_property, error.error_message, error
                 )

--- a/src/webpub_manifest_parser/core/syntax.py
+++ b/src/webpub_manifest_parser/core/syntax.py
@@ -279,6 +279,9 @@ class SyntaxAnalyzer(BaseAnalyzer):
             try:
                 property_value = object_property.parser.parse(property_value)
             except ValueParserError as error:
+                self._logger.error(
+                    f"Error while parsing {property_value} for {object_property.key}, falling back to default"
+                )
                 # First, fallback to the default value for the property, then re-raise
                 property_value = self._format_property_value(
                     object_property.default_value, object_property

--- a/src/webpub_manifest_parser/core/syntax.py
+++ b/src/webpub_manifest_parser/core/syntax.py
@@ -279,6 +279,8 @@ class SyntaxAnalyzer(BaseAnalyzer):
             try:
                 property_value = object_property.parser.parse(property_value)
             except ValueParserError as error:
+                # First, fallback to the default value for the property, then re-raise
+                setattr(ast_object, object_property_name, object_property.default_value)        
                 raise SyntaxAnalyzerError(
                     ast_object, object_property, error.error_message, error
                 )

--- a/src/webpub_manifest_parser/core/syntax.py
+++ b/src/webpub_manifest_parser/core/syntax.py
@@ -280,7 +280,9 @@ class SyntaxAnalyzer(BaseAnalyzer):
                 property_value = object_property.parser.parse(property_value)
             except ValueParserError as error:
                 # First, fallback to the default value for the property, then re-raise
-                property_value = self._format_property_value(object_property.default_value, object_property)
+                property_value = self._format_property_value(
+                    object_property.default_value, object_property
+                )
                 setattr(ast_object, object_property_name, property_value)
                 raise SyntaxAnalyzerError(
                     ast_object, object_property, error.error_message, error

--- a/tests/webpub_manifest_parser/opds2/test_parser.py
+++ b/tests/webpub_manifest_parser/opds2/test_parser.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import os
 from unittest import TestCase
 
@@ -203,3 +204,18 @@ class OPDS2ParserTest(TestCase):
         self.assertEqual(
             "application/epub+zip", indirect_acquisition_object.child[0].type
         )
+
+    def test_incorrect_language_fallback(self):
+        """Whenever an incorrectly formatted language code is encountered
+        the languages property should fallback to the default `[]`
+        and not be set to the unsupported NoneType value
+        """
+        parser_factory = OPDS2FeedParserFactory()
+        parser = parser_factory.create()
+        with open("tests/files/opds2/feed.json") as fp:
+            feed = json.load(fp)
+        feed["publications"][0]["metadata"]["language"] = "en uk"
+        feed["publications"] = [feed["publications"][0]]
+        
+        result = parser.parse_json(feed)
+        assert [] == result.root.publications[0].metadata.languages

--- a/tests/webpub_manifest_parser/opds2/test_parser.py
+++ b/tests/webpub_manifest_parser/opds2/test_parser.py
@@ -216,6 +216,6 @@ class OPDS2ParserTest(TestCase):
             feed = json.load(fp)
         feed["publications"][0]["metadata"]["language"] = "en uk"
         feed["publications"] = [feed["publications"][0]]
-        
+
         result = parser.parse_json(feed)
         assert [] == result.root.publications[0].metadata.languages


### PR DESCRIPTION
…None value

None values may be unsupported for the given property.
Eg. Languages from the ticket
If an unsupproted language code is encountered (en<space>uk) then the languages value becomes "None" which is an unexpected value further down the stack (iterators are expected).
[Notion](https://www.notion.so/lyrasis/Webpub-manifest-parser-Fix-the-object-hash-method-to-not-crash-for-nonetype-lists-89ad6ac200644790aafc27d6591c4507)
