### PR TITLE
Fixes the isort incompatability with the new poetry-core

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
         name: Run black
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.11.5
     hooks:
       - id: isort
         name: Run isort


### PR DESCRIPTION
By upgrading the isort version

Full explanation in [this blog article](https://levelup.gitconnected.com/fix-runtimeerror-poetry-isort-5db7c67b60ff)