### PR TITLE
Fix bug where open access titles in ODL feeds would fail to import (PP-847)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core>=1.0.0"]
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-build-backend = "poetry.masonry.api"
 requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.isort]
 profile = "black"

--- a/src/webpub_manifest_parser/odl/semantic.py
+++ b/src/webpub_manifest_parser/odl/semantic.py
@@ -196,7 +196,7 @@ class ODLSemanticAnalyzer(SemanticAnalyzer):
         self._logger.debug(f"Started processing {encode(node)}")
 
         if (not node.licenses or len(node.licenses) == 0) and (
-            (not node.licenses or len(node.links) == 0)
+            (not node.links or len(node.links) == 0)
             or not node.links.get_by_rel(OPDS2LinkRelationsRegistry.OPEN_ACCESS.key)
         ):
             with self._record_errors():

--- a/tests/webpub_manifest_parser/odl/test_semantic.py
+++ b/tests/webpub_manifest_parser/odl/test_semantic.py
@@ -187,28 +187,36 @@ class ODLSemanticAnalyzerTest(AnalyzerTest):
                 ],
             ),
             (
-                    "when_publication_does_not_contain_neither_licenses_nor_oa_link",
-                    ODLFeed(
-                        metadata=OPDS2FeedMetadata(title="test"),
-                        links=LinkList(
-                            [
-                                Link(
-                                    href="http://example.com",
-                                    rels=[LinkRelationsRegistry.SELF.key],
-                                )
-                            ]
-                        ),
-                        publications=CollectionList(
-                            [
-                                ODLPublication(
-                                    metadata=PresentationMetadata(title="Publication 1"),
-                                    links=LinkList([Link(href="http://example.com", rels=[OPDS2LinkRelationsRegistry.OPEN_ACCESS.key])]),
-                                )
-                            ]
-                        ),
+                "when_publication_does_not_contain_neither_licenses_nor_oa_link",
+                ODLFeed(
+                    metadata=OPDS2FeedMetadata(title="test"),
+                    links=LinkList(
+                        [
+                            Link(
+                                href="http://example.com",
+                                rels=[LinkRelationsRegistry.SELF.key],
+                            )
+                        ]
                     ),
-                    [
-                    ],
+                    publications=CollectionList(
+                        [
+                            ODLPublication(
+                                metadata=PresentationMetadata(title="Publication 1"),
+                                links=LinkList(
+                                    [
+                                        Link(
+                                            href="http://example.com",
+                                            rels=[
+                                                OPDS2LinkRelationsRegistry.OPEN_ACCESS.key
+                                            ],
+                                        )
+                                    ]
+                                ),
+                            )
+                        ]
+                    ),
+                ),
+                [],
             ),
             (
                 "when_license_does_not_contain_self_link_and_borrow_link",

--- a/tests/webpub_manifest_parser/odl/test_semantic.py
+++ b/tests/webpub_manifest_parser/odl/test_semantic.py
@@ -127,7 +127,7 @@ class ODLSemanticAnalyzerTest(AnalyzerTest):
                 ],
             ),
             (
-                "when_publication_does_not_contain_neither_licenses_nor_oa_link",
+                "when_publication_does_not_contain_licenses_and_has_a_oa_link",
                 ODLFeed(
                     metadata=OPDS2FeedMetadata(title="test"),
                     links=LinkList(
@@ -185,6 +185,30 @@ class ODLSemanticAnalyzerTest(AnalyzerTest):
                         node_property=None,
                     )
                 ],
+            ),
+            (
+                    "when_publication_does_not_contain_neither_licenses_nor_oa_link",
+                    ODLFeed(
+                        metadata=OPDS2FeedMetadata(title="test"),
+                        links=LinkList(
+                            [
+                                Link(
+                                    href="http://example.com",
+                                    rels=[LinkRelationsRegistry.SELF.key],
+                                )
+                            ]
+                        ),
+                        publications=CollectionList(
+                            [
+                                ODLPublication(
+                                    metadata=PresentationMetadata(title="Publication 1"),
+                                    links=LinkList([Link(href="http://example.com", rels=[OPDS2LinkRelationsRegistry.OPEN_ACCESS.key])]),
+                                )
+                            ]
+                        ),
+                    ),
+                    [
+                    ],
             ),
             (
                 "when_license_does_not_contain_self_link_and_borrow_link",


### PR DESCRIPTION
We should be supporting this case, but there was a bug in the parser preventing it. The fix is one line, but I also added a test to make sure we are handling this case.