### PR TITLE
Relax requirement for ODL feeds to have an OA acquisition link (PP-1530)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,26 @@ A parser for the
 [Open Publication Distribution System 2.0 (OPDS 2.0)](https://drafts.opds.io/opds-2.0), and
 [Open Distribution to Libraries 1.0 (ODL)](https://drafts.opds.io/odl-1.0.html) formats.
 
+**Note**: This parser varys from the OPDS 2 + ODL spec in that it allows OPDS 2 + ODL feeds to contain
+non-open access acquisition links.
+
+The spec [defines](https://drafts.opds.io/odl-1.0.html#21-opds-20) an OPDS 2 + ODL feed as:
+
+- It must be a valid OPDS Feed as defined in [[OPDS-2](https://drafts.opds.io/odl-1.0.html#normative-references)] with
+  one difference:
+    - The requirement for the presence of an Acquisition Link is relaxed
+    - Instead, each Publication listed in publications must either contain a licenses subcollection or an Open-Access
+      Acquisition Link (http://opds-spec.org/acquisition/open-access)
+
+The requirement that each link be an Open-Access Acquisition Link is overly restrictive, and prevents us from importing
+mixed OPDS2 and OPDS2 + ODL feeds. We relax the requirement to:
+
+- It must be a valid OPDS Feed as defined in [[OPDS-2](https://drafts.opds.io/odl-1.0.html#normative-references)] with
+  one difference:
+    - The requirement for the presence of an Acquisition Link is relaxed
+    - Instead, each Publication listed in publications must either contain a licenses subcollection or an
+      **Acquisition Link** (http://opds-spec.org/acquisition)
+
 ## Usage
 
 Install the library with `pip`

--- a/tests/webpub_manifest_parser/odl/test_semantic.py
+++ b/tests/webpub_manifest_parser/odl/test_semantic.py
@@ -22,7 +22,7 @@ from webpub_manifest_parser.odl.semantic import (
     ODL_FEED_MISSING_PUBLICATIONS_SUBCOLLECTION_ERROR,
     ODL_LICENSE_MUST_CONTAIN_CHECKOUT_LINK_TO_LICENSE_STATUS_DOCUMENT_ERROR,
     ODL_LICENSE_MUST_CONTAIN_SELF_LINK_TO_LICENSE_INFO_DOCUMENT_ERROR,
-    ODL_PUBLICATION_MUST_CONTAIN_EITHER_LICENSES_OR_OA_ACQUISITION_LINK_ERROR,
+    ODL_PUBLICATION_MUST_CONTAIN_EITHER_LICENSES_OR_ACQUISITION_LINK_ERROR,
     ODLSemanticAnalyzer,
 )
 from webpub_manifest_parser.opds2 import (
@@ -123,7 +123,7 @@ class ODLSemanticAnalyzerTest(AnalyzerTest):
                 ],
             ),
             (
-                "when_publication_does_not_contain_neither_licenses_nor_oa_link",
+                "when_publication_does_not_contain_licenses_nor_acquisition_link",
                 ODLFeed(
                     metadata=OPDS2FeedMetadata(title="test"),
                     links=LinkList(
@@ -146,7 +146,7 @@ class ODLSemanticAnalyzerTest(AnalyzerTest):
                     ),
                 ),
                 [
-                    ODL_PUBLICATION_MUST_CONTAIN_EITHER_LICENSES_OR_OA_ACQUISITION_LINK_ERROR(
+                    ODL_PUBLICATION_MUST_CONTAIN_EITHER_LICENSES_OR_ACQUISITION_LINK_ERROR(
                         node=ODLPublication(
                             metadata=OPDS2PublicationMetadata(title="Publication 1")
                         ),
@@ -155,7 +155,7 @@ class ODLSemanticAnalyzerTest(AnalyzerTest):
                 ],
             ),
             (
-                "when_publication_does_not_contain_neither_licenses_nor_oa_link",
+                "when_publication_does_not_contain_licenses_nor_acquisition_link",
                 ODLFeed(
                     metadata=OPDS2FeedMetadata(title="test"),
                     links=LinkList(
@@ -178,7 +178,7 @@ class ODLSemanticAnalyzerTest(AnalyzerTest):
                     ),
                 ),
                 [
-                    ODL_PUBLICATION_MUST_CONTAIN_EITHER_LICENSES_OR_OA_ACQUISITION_LINK_ERROR(
+                    ODL_PUBLICATION_MUST_CONTAIN_EITHER_LICENSES_OR_ACQUISITION_LINK_ERROR(
                         node=ODLPublication(
                             metadata=OPDS2PublicationMetadata(title="Publication 1")
                         ),
@@ -210,6 +210,74 @@ class ODLSemanticAnalyzerTest(AnalyzerTest):
                                             href="http://example.com",
                                             rels=[
                                                 OPDS2LinkRelationsRegistry.OPEN_ACCESS.key
+                                            ],
+                                        )
+                                    ]
+                                ),
+                            )
+                        ]
+                    ),
+                ),
+                [],
+            ),
+            (
+                "when_publication_does_not_contain_licenses_and_has_an_acquisition_link",
+                ODLFeed(
+                    metadata=OPDS2FeedMetadata(title="test"),
+                    links=LinkList(
+                        [
+                            Link(
+                                href="http://example.com",
+                                rels=[LinkRelationsRegistry.SELF.key],
+                            )
+                        ]
+                    ),
+                    publications=CollectionList(
+                        [
+                            ODLPublication(
+                                metadata=OPDS2PublicationMetadata(
+                                    title="Publication 1"
+                                ),
+                                links=LinkList(
+                                    [
+                                        Link(
+                                            href="http://example.com",
+                                            rels=[
+                                                OPDS2LinkRelationsRegistry.ACQUISITION.key
+                                            ],
+                                        )
+                                    ]
+                                ),
+                            )
+                        ]
+                    ),
+                ),
+                [],
+            ),
+            (
+                "when_publication_does_not_contain_licenses_and_has_an_acquisition_link",
+                ODLFeed(
+                    metadata=OPDS2FeedMetadata(title="test"),
+                    links=LinkList(
+                        [
+                            Link(
+                                href="http://example.com",
+                                rels=[LinkRelationsRegistry.SELF.key],
+                            )
+                        ]
+                    ),
+                    publications=CollectionList(
+                        [
+                            ODLPublication(
+                                metadata=OPDS2PublicationMetadata(
+                                    title="Publication 1"
+                                ),
+                                links=LinkList(
+                                    [
+                                        Link(
+                                            href="http://example.com",
+                                            rels=[
+                                                OPDS2LinkRelationsRegistry.ACQUISITION.key
                                             ],
                                         )
                                     ]

--- a/tests/webpub_manifest_parser/odl/test_semantic.py
+++ b/tests/webpub_manifest_parser/odl/test_semantic.py
@@ -255,7 +255,7 @@ class ODLSemanticAnalyzerTest(AnalyzerTest):
                 [],
             ),
             (
-                "when_publication_does_not_contain_licenses_and_has_an_acquisition_link",
+                "when_publication_does_not_contain_licenses_and_has_an_unknown_acquisition_link",
                 ODLFeed(
                     metadata=OPDS2FeedMetadata(title="test"),
                     links=LinkList(
@@ -277,7 +277,7 @@ class ODLSemanticAnalyzerTest(AnalyzerTest):
                                         Link(
                                             href="http://example.com",
                                             rels=[
-                                                OPDS2LinkRelationsRegistry.ACQUISITION.key
+                                                f"{OPDS2LinkRelationsRegistry.ACQUISITION.key}/unknown"
                                             ],
                                         )
                                     ]

--- a/tests/webpub_manifest_parser/odl/test_semantic.py
+++ b/tests/webpub_manifest_parser/odl/test_semantic.py
@@ -123,7 +123,7 @@ class ODLSemanticAnalyzerTest(AnalyzerTest):
                 ],
             ),
             (
-                "when_publication_does_not_contain_licenses_nor_acquisition_link",
+                "when_publication_contains_neither_licenses_nor_acquisition_link",
                 ODLFeed(
                     metadata=OPDS2FeedMetadata(title="test"),
                     links=LinkList(
@@ -155,7 +155,7 @@ class ODLSemanticAnalyzerTest(AnalyzerTest):
                 ],
             ),
             (
-                "when_publication_does_not_contain_licenses_nor_acquisition_link",
+                "when_publication_contains_neither_licenses_nor_acquisition_link",
                 ODLFeed(
                     metadata=OPDS2FeedMetadata(title="test"),
                     links=LinkList(


### PR DESCRIPTION
The spec [defines](https://drafts.opds.io/odl-1.0.html#21-opds-20) an OPDS 2 + ODL feed as:
- It must be a valid OPDS Feed as defined in [[OPDS-2](https://drafts.opds.io/odl-1.0.html#normative-references)] with one difference:
  - The requirement for the presence of an Acquisition Link is relaxed
  - Instead, each Publication listed in publications must either contain a licenses subcollection or an Open-Access Acquisition Link (http://opds-spec.org/acquisition/open-access)

The requirement that each link be an Open-Access Acquisition Link is overly restrictive, and prevents us from importing mixed OPDS2 and OPDS2 + ODL feeds. We relax that requirement to:
  - Instead, each Publication listed in publications must either contain a licenses subcollection or an acquisition Link (link that starts with http://opds-spec.org/acquisition). 

See [PP-1530](https://ebce-lyrasis.atlassian.net/browse/PP-1530) for more info.

[PP-1530]: https://ebce-lyrasis.atlassian.net/browse/PP-1530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ